### PR TITLE
Add: submitボタンを透明にし、formのonchangeでクリックされるよう設定

### DIFF
--- a/app/javascript/src/submit.js
+++ b/app/javascript/src/submit.js
@@ -14,10 +14,16 @@ submitImage = () => {
     reader.readAsDataURL(file);
   }
 
-  // POSTリクエスト
-  const xhr = new XMLHttpRequest();
-  const form = document.getElementById('image_form');
-  const formData = new FormData(form);
-  xhr.open("POST", "/uploads", true);
-  xhr.send(formData);
+  // 画像送信機能
+  document.querySelector("#submit_button").click();
+  
+  // 以下コードではなぜかcreate.js.erbを参照できずUnknownFormatエラーが発生。
+  // const form = document.getElementById('image_form');
+  // xhr.send(formData);
+
+  // 以下コードではエラーは起きないがなぜかcreate.js.erbの内容がビューに反映されず。
+  // const xhr = new XMLHttpRequest();
+  // const formData = new FormData(form);
+  // xhr.open("POST", "/uploads", true);
+  // xhr.send(formData);
 }

--- a/app/views/uploads/new.html.slim
+++ b/app/views/uploads/new.html.slim
@@ -5,7 +5,7 @@ p アイコンをタップして写真をアップロード
 = form_with url: uploads_path, local: false, id: 'image_form' do |f|
   .form-group
     = f.file_field :room_image, accept: 'image/*', onchange: 'submitImage()'
-    = f.button :submit
+    = f.button :submit, id: 'submit_button', style: "visibility:hidden;"
   img#preview width="auto" height="500px"
 
 .result


### PR DESCRIPTION
送信ボタンを押さずとも、ファイルをアップロードした時点でformがsubmitされるよう実装。

submit.js内に以下いずれかのコードを記述して上記を実現しようとしたが、
①formに対してsubmit()メソッドを実行
②/uploadsへのXMLHttpRequestを作成し送信

①ではなぜかcreate.js.erbを参照できずUnknownFormatエラーが発生し、
②ではエラーは起きないがなぜかcreate.js.erbの内容がビューに反映されないという問題が発生。

応急処置として、
③submitボタンをvisibility:hiddenにしたうえで、submit.jsにてsubmitボタンに対するclick()メソッドを記述する
という方法を採用。

①②のエラー原因は別途究明。