### PR TITLE
Delete submit button 2

### DIFF
--- a/app/javascript/src/submit.js
+++ b/app/javascript/src/submit.js
@@ -19,10 +19,11 @@ submitImage = () => {
   
   // 以下コードではなぜかcreate.js.erbを参照できずUnknownFormatエラーが発生。
   // const form = document.getElementById('image_form');
-  // xhr.send(formData);
+  // form.submit();
 
   // 以下コードではエラーは起きないがなぜかcreate.js.erbの内容がビューに反映されず。
   // const xhr = new XMLHttpRequest();
+  // const form = document.getElementById('image_form');
   // const formData = new FormData(form);
   // xhr.open("POST", "/uploads", true);
   // xhr.send(formData);

--- a/app/javascript/src/submit.js
+++ b/app/javascript/src/submit.js
@@ -1,10 +1,10 @@
 submitImage = () => {
   // プレビュー機能
-  const target = document.querySelector("#room_image");
+  const target = document.getElementById("room_image");
   const file = target.files[0];
   const reader = new FileReader();
   reader.onloadend = () => {
-    const preview = document.querySelector("#preview");
+    const preview = document.getElementById("preview");
     
     if (preview) {
       preview.src = reader.result;
@@ -15,16 +15,14 @@ submitImage = () => {
   }
 
   // 画像送信機能
-  document.querySelector("#submit_button").click();
-  
-  // 以下コードではなぜかcreate.js.erbを参照できずUnknownFormatエラーが発生。
-  // const form = document.getElementById('image_form');
-  // form.submit();
-
-  // 以下コードではエラーは起きないがなぜかcreate.js.erbの内容がビューに反映されず。
-  // const xhr = new XMLHttpRequest();
-  // const form = document.getElementById('image_form');
-  // const formData = new FormData(form);
-  // xhr.open("POST", "/uploads", true);
-  // xhr.send(formData);
+  const form = document.getElementById('image_form');
+  const formData = new FormData(form);
+  $.ajax({
+    url: form.action,
+    type: form.method,
+    data: formData,
+    processData: false,
+    contentType: false,
+    cache: false
+  });
 }

--- a/app/views/uploads/new.html.slim
+++ b/app/views/uploads/new.html.slim
@@ -5,7 +5,6 @@ p アイコンをタップして写真をアップロード
 = form_with url: uploads_path, local: false, id: 'image_form' do |f|
   .form-group
     = f.file_field :room_image, accept: 'image/*', onchange: 'submitImage()'
-    = f.button :submit, id: 'submit_button', style: "visibility:hidden;"
   img#preview width="auto" height="500px"
 
 .result


### PR DESCRIPTION
画像をアップロードしたときのonchangeイベントでUploads#createアクションを発火するため、
「visibility:hiddenにしたsubmitボタンに対してclick()メソッドを実行する」
という方法を採用していたが、これをajaxメソッドに変更。