### PR TITLE
Rid fat controller

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -11,8 +11,7 @@ class UploadsController < ApplicationController
 
     @detected_items = detect_items(room_image)
 
-    @judged_items = []
-    @unregd_items = []
+    @judged_items = []; @unregd_items = []
     @detected_items&.each do |detected_item|
       if Item.find_by(name: detected_item)&.why_release.present?
         @judged_items << detected_item

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -10,21 +10,17 @@ class UploadsController < ApplicationController
   def create
     room_image = Base64.strict_encode64(params[:room_image].read)
 
-    if @detected_items = detect_items(room_image)
-      @judged_items = []
-      @unregd_items = []
-  
-      @detected_items&.each do |detected_item|
-        if Item.find_by(name: detected_item)&.why_release.present?
-          @judged_items << detected_item
-        else
-          @unregd_items << detected_item
-          Item.create(name: detected_item) unless Item.exists?(name: detected_item)
-        end
+    @detected_items = detect_items(room_image)
+
+    @judged_items = []
+    @unregd_items = []
+    @detected_items&.each do |detected_item|
+      if Item.find_by(name: detected_item)&.why_release.present?
+        @judged_items << detected_item
+      else
+        @unregd_items << detected_item
+        Item.create(name: detected_item) unless Item.exists?(name: detected_item)
       end
-    else
-      flash.now[:danger] = 'APIリクエストが失敗しています'
-      render :new
     end
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -2,7 +2,6 @@ require 'net/http'
 
 class UploadsController < ApplicationController
   include UploadsHelper
-  before_action :require_image, only: :create
 
   def new
   end
@@ -21,15 +20,6 @@ class UploadsController < ApplicationController
         @unregd_items << detected_item
         Item.create(name: detected_item) unless Item.exists?(name: detected_item)
       end
-    end
-  end
-
-  private
-
-  def require_image
-    if params[:room_image].nil?
-      flash.now[:danger] = '画像を登録してください'
-      render :new
     end
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -9,8 +9,10 @@ class UploadsController < ApplicationController
   def create
     room_image = Base64.strict_encode64(params[:room_image].read)
 
+    # アップロードされた画像を解析
     @detected_items = detect_items(room_image)
 
+    # 検出したモノを登録有無によって仕分け
     @judged_items = []; @unregd_items = []
     @detected_items&.each do |detected_item|
       if Item.find_by(name: detected_item)&.why_release.present?

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -28,11 +28,11 @@ class UploadsController < ApplicationController
       ]
     }.to_json
 
-    response = Net::HTTP.post(vision_api_url, body, headers)
+    response_from_vision_api = Net::HTTP.post(vision_api_url, body, headers)
 
-    if response.code == '200'
+    if response_from_vision_api.code == '200'
       # 検出されたオブジェクトの配列を作成
-      @detected_items = JSON.parse(response.body)['responses'][0]["localizedObjectAnnotations"]&.map {|i| i['name']}&.uniq
+      @detected_items = JSON.parse(response_from_vision_api.body)['responses'][0]["localizedObjectAnnotations"]&.map {|i| i['name']}&.uniq
 
       # 日本語に変換
       if @detected_items.present?
@@ -45,13 +45,9 @@ class UploadsController < ApplicationController
           target: "ja"
         }.to_json
 
-        response = Net::HTTP.post(
-          translation_api_url,
-          body,
-          headers
-        )
+        response_from_transition_api = Net::HTTP.post(translation_api_url, body, headers)
 
-        @detected_items = JSON.parse(response.body)['data']['translations']&.map {|i| i['translatedText']}
+        @detected_items = JSON.parse(response_from_transition_api.body)['data']['translations']&.map {|i| i['translatedText']}
       end
 
       # オブジェクト名称の登録有無による仕分け
@@ -67,7 +63,7 @@ class UploadsController < ApplicationController
         end
       end
     else
-      flash.now[:danger] = 'APIリクエストが失敗しています'
+      flash.now[:danger] = '申し訳ございません。エラーが発生しておりますのでアップデートをお待ちください。'
       render :new
     end
   end

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -1,8 +1,4 @@
 module UploadsHelper
-  def scan
-    
-  end
-
   def twitter_share_url(detected_items)
     link = request.protocol + request.host + "%0a"
     sentence = "これらは手放すべき？%0aご意見・コメントお待ちしてます%0a"

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -24,7 +24,7 @@ module UploadsHelper
   
     if response_from_vision_api.code == '200'
       detected_items = JSON.parse(response_from_vision_api.body)['responses'][0]["localizedObjectAnnotations"]&.map {|i| i['name']}&.uniq
-      return translate_into_ja(detected_items)
+      detected_items.present? ? translate_into_ja(detected_items) : nil
     else
       flash.now[:danger] = '申し訳ございません。エラーが発生しておりますのでアップデートをお待ちください。'
       render :new
@@ -38,7 +38,7 @@ module UploadsHelper
     body = { q: detected_items, source: "en", target: "ja" }.to_json
   
     response_from_transition_api = Net::HTTP.post(translation_api_url, body, headers)
-    return JSON.parse(response_from_transition_api.body)['data']['translations']&.map {|i| i['translatedText']}
+    JSON.parse(response_from_transition_api.body)['data']['translations']&.map {|i| i['translatedText']}
   end
 
   def twitter_share_url(detected_items)

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -26,7 +26,7 @@ module UploadsHelper
       detected_items = JSON.parse(response_from_vision_api.body)['responses'][0]["localizedObjectAnnotations"]&.map {|i| i['name']}&.uniq
       detected_items.present? ? translate_into_ja(detected_items) : nil
     else
-      flash.now[:danger] = '申し訳ございません。エラーが発生しておりますのでアップデートをお待ちください。'
+      flash.now[:danger] = '予期せぬエラーが発生しておりますので申し訳ありませんがアップデートをお待ちください。'
       render :new
     end
   end

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -1,4 +1,45 @@
 module UploadsHelper
+  def detect_items(room_image)
+    vision_api_key = Rails.application.credentials.gcp[:vision_api][:api_key]
+    vision_api_url = URI("https://vision.googleapis.com/v1/images:annotate?key=#{vision_api_key}")
+    headers = { "Content-Type" => "application/json" }
+  
+    body = {
+      requests: [
+        {
+          features: [
+            {
+              maxResults: 10,
+              type: "OBJECT_LOCALIZATION"
+            }
+          ],
+          image: {
+            content: room_image
+          }
+        }
+      ]
+    }.to_json
+  
+    response_from_vision_api = Net::HTTP.post(vision_api_url, body, headers)
+  
+    if response_from_vision_api.code == '200'
+      detected_items = JSON.parse(response_from_vision_api.body)['responses'][0]["localizedObjectAnnotations"]&.map {|i| i['name']}&.uniq
+      return translate_into_ja(detected_items)
+    else
+      flash.now[:danger] = '申し訳ございません。エラーが発生しておりますのでアップデートをお待ちください。'
+      render :new
+    end
+  end
+  
+  def translate_into_ja(detected_items)
+    translation_api_key = Rails.application.credentials.gcp[:translation_api][:api_key]
+    translation_api_url = URI("https://translation.googleapis.com/language/translate/v2?key=#{translation_api_key}")
+    body = { q: detected_items, source: "en", target: "ja" }.to_json
+  
+    response_from_transition_api = Net::HTTP.post(translation_api_url, body, headers)
+    return JSON.parse(response_from_transition_api.body)['data']['translations']&.map {|i| i['translatedText']}
+  end
+
   def twitter_share_url(detected_items)
     link = request.protocol + request.host + "%0a"
     sentence = "これらは手放すべき？%0aご意見・コメントお待ちしてます%0a"

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -34,6 +34,7 @@ module UploadsHelper
   def translate_into_ja(detected_items)
     translation_api_key = Rails.application.credentials.gcp[:translation_api][:api_key]
     translation_api_url = URI("https://translation.googleapis.com/language/translate/v2?key=#{translation_api_key}")
+    headers = { "Content-Type" => "application/json" }
     body = { q: detected_items, source: "en", target: "ja" }.to_json
   
     response_from_transition_api = Net::HTTP.post(translation_api_url, body, headers)

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -1,4 +1,8 @@
 module UploadsHelper
+  def scan
+    
+  end
+
   def twitter_share_url(detected_items)
     link = request.protocol + request.host + "%0a"
     sentence = "これらは手放すべき？%0aご意見・コメントお待ちしてます%0a"

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -43,7 +43,7 @@ module UploadsHelper
 
   def twitter_share_url(detected_items)
     link = request.protocol + request.host + "%0a"
-    sentence = "これらは手放すべき？%0aご意見・コメントお待ちしてます%0a"
+    sentence = "これらは捨てるべき？%0aご意見・コメントお待ちしてます%0a"
     items = detected_items.map {|detected_item| "・" + detected_item + "%0a"}.join + "%0a"
     hashtags = "いらないモノ診断,ミニマリスト"
 


### PR DESCRIPTION
・コントローラの処理をヘルパーに移管し、ファットコントローラを解消
・送信ボタンない現状、require_imageのbefore_actionは必要ないので削除
・APIでエラーが出たときのメッセージをユーザー目線に変更